### PR TITLE
Switched MvCLOSEVIEW snippet `VALUE` attribute to `VIEW` attribute

### DIFF
--- a/snippets/MivaScript/Tags/MvCLOSEVIEW.sublime-snippet
+++ b/snippets/MivaScript/Tags/MvCLOSEVIEW.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-<MvCLOSEVIEW VALUE = "${1:\{ ${2:expression | [string] literal} \}}" ${3:NAME = "${4:\{ ${5:expression | database alias} \}}"}>
+<MvCLOSEVIEW ${1:NAME = "${2:\{ ${3:expression | database alias} \}}"} VIEW = "${4:\{ ${5:expression | [string] literal} \}}">
 ]]></content>
 	<!-- Optional: Set a tabTrigger to define how to trigger the snippet -->
 	<tabTrigger>mvcloseview</tabTrigger>


### PR DESCRIPTION
Even though the http://www.mivascript.com/item/MvCLOSEVIEW.html page describes the syntax as
```
<MvCLOSEVIEW NAME = "string: {  expression } | literal" VALUE = "{ expression } | literal"> 
```
that will throw an error in the compiler, and it should be:
```
<MvCLOSEVIEW NAME = "string: {  expression } | literal" VIEW = "{ expression } | literal"> 
```